### PR TITLE
Modify copy command to not include folder

### DIFF
--- a/docs/linux_kernel_development/index.mdx
+++ b/docs/linux_kernel_development/index.mdx
@@ -654,7 +654,7 @@ We will instruct BusyBox to install all the links at boot time. If you want to a
 them at boot, you can copy all the links using
 
 ```shell
-$ cp -r _install/ $INIT_RAM_FS/
+$ cp -r _install/* $INIT_RAM_FS/
 ```
 :::
 


### PR DESCRIPTION
Updated the copy command to include all files in the install directory, but not the folder itself.